### PR TITLE
Uppercase status example values

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -61,7 +61,7 @@ inputs:
     description: 'The port action external run id'
   status:
     required: false
-    description: 'The port action status (success, failure)'
+    description: 'The port action status (SUCCESS, FAILURE)'
   logMessage:
     required: false
     description: 'The port action log message'


### PR DESCRIPTION
# Description

Uppercasing status input example values, to avoid errors when blindly copying.

Error when using copied value `failure`:

`Error: PATCH_RUN Operation - status must be one of SUCCESS or FAILURE`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)