### PR TITLE
chore: bump actions/checkout to v6 in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
     - uses: Songmu/tagpr@v1
       id: tagpr
       env:


### PR DESCRIPTION
## Summary

- Updates `actions/checkout` from v3 to v6 in `.github/workflows/release.yml`.
- `.github/workflows/test.yml` was already on v6; this was the only remaining reference in the repo.

Note: Dependabot PR #185 also bumps checkout (and includes a change to `test.yml`). This PR only updates `release.yml` to avoid overlapping diffs.

## Test plan

- [ ] Release workflow runs successfully on merge.


Made with [Cursor](https://cursor.com)